### PR TITLE
Untitled

### DIFF
--- a/phpfpm_average
+++ b/phpfpm_average
@@ -15,6 +15,8 @@
 #%# family=manual
 #%# capabilities=autoconf
 
+PHP_BIN=${phpbin-"php5-fpm"}
+
 if [ "$1" = "autoconf" ]; then
 echo yes
 exit 0
@@ -33,5 +35,5 @@ exit 0
 fi
 
 echo -n "php_average.value "
-ps awwwux | grep php5-fpm | grep -v grep | awk '{mem = $6; tot = $6 + tot; total++} END{printf("%d\n", mem / total, tot / 1024)}'
+ps awwwux | grep $PHP_BIN | grep -v grep | awk '{mem = $6; tot = $6 + tot; total++} END{printf("%d\n", mem / total, tot / 1024)}'
 

--- a/phpfpm_connections
+++ b/phpfpm_connections
@@ -49,6 +49,8 @@ graph_order Connections
 graph_info Plugin created by TJ Stein
 accepted.label Idle
 accepted.draw AREA
+accepted.type DERIVE
+accepted.min 0
 ');
 
 	exit 0;

--- a/phpfpm_memory
+++ b/phpfpm_memory
@@ -4,6 +4,8 @@
 #
 # Copyright TJ Stein 2010 http://constantshift.com
 
+my $PHP_BIN = exists $ENV{'phpbin'} ? $ENV{'phpbin'} : "php5-fpm";
+
 if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
         print "graph_title PHP5-FPM Memory Usage\n";
         print "graph_vlabel RAM\n";
@@ -12,7 +14,7 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
                 print "graph_args --base 1024\n";
 } else {
         my $i = Integer;
-        @cmd = `ps auwx | grep php | grep -v grep | grep -v phpfpm_memory`;
+        @cmd = `ps auwx | grep $PHP_BIN | grep -v grep | grep -v phpfpm_memory`;
 
         foreach (@cmd) {
                 @return = split(/ +/, $_);

--- a/phpfpm_processes
+++ b/phpfpm_processes
@@ -15,6 +15,8 @@
 #%# family=manual
 #%# capabilities=autoconf
 
+PHP_BIN=${phpbin-"php5-fpm"}
+
 if [ "$1" = "autoconf" ]; then
 echo yes
 exit 0
@@ -33,4 +35,4 @@ exit 0
 fi
 
 echo -n "php_processes.value "
-pgrep -c php5-fpm
+pgrep -c $PHP_BIN


### PR DESCRIPTION
I've taken your very useful php-fpm munin plugin and added a env.phpbin variable to change the PHP binary name (when compiled by hand PHP5.3.5 calls the binary php-fpm, not php5-bin). I accidentally also included in this commit a change to phpfpm_connections that makes the graph a DERIVE type rather than the default incremental. It makes more sense to me like that, but I can take it out if you don't want it.
