### PR TITLE
phpfpm_average: emit value in correct unit

### DIFF
--- a/phpfpm_average
+++ b/phpfpm_average
@@ -35,5 +35,5 @@ exit 0
 fi
 
 echo -n "php_average.value "
-ps awwwux | grep $PHP_BIN | grep -v grep | grep -v master | awk '{total_mem = $6 + total_mem; total_proc++} END{printf("%d\n", total_mem / total_proc)}'
+ps awwwux | grep $PHP_BIN | grep -v grep | grep -v master | awk '{total_mem = $6 * 1024 + total_mem; total_proc++} END{printf("%d\n", total_mem / total_proc)}'
 


### PR DESCRIPTION
ps reports memory sizes in KBytes, so we should multiply in order for munin to graph the value correctly.

Otherwise, the phpfpm_average graph makes no sense what so ever when looked at together with phpfpm_memory (where the value is multiplied correctly)
