### PR TITLE
Update phpfpm_processes to works greatly with phpbin settings

### DIFF
--- a/phpfpm_processes
+++ b/phpfpm_processes
@@ -35,4 +35,4 @@ exit 0
 fi
 
 echo -n "php_processes.value "
-pgrep $PHP_BIN | wc -l
+ps awwwux | grep $PHP_BIN | grep -v grep | wc -l


### PR DESCRIPTION
I had an issue on my debian Wheezy installation with the phpfpm_processes.
After investigation and reading the others scripts, I found out that using "pgrep" command was not working greatly.

I updated phpfpm_processes to work the same way phpfpm_avergage is doing to retrieve all the processes.

I wasn't sure to include or not master processes.
As the old script when working with my environment was also returnin master process in it, I did so.

Hope it helps.
