### PR TITLE
Fix an issue in which the graph is not displayed.

### DIFF
--- a/phpfpm_connections
+++ b/phpfpm_connections
@@ -45,7 +45,6 @@ if ( defined $ARGV[0] and $ARGV[0] eq "config" )
 graph_args --base 1024 -l 0
 graph_vlabel Connections
 graph_category PHP
-graph_order Connections
 graph_info Plugin created by TJ Stein
 accepted.label Idle
 accepted.draw AREA


### PR DESCRIPTION
Graph of phpfpm_connections is not displayed.

/var/log/munin/munin-graph.log

```
Unable to graph /var/lib/munin/foo/foo-phpfpm_connections-accepted-d.rrd: opening '/var/lib/munin/foo/foo-phpfpm_connections-Connections-g.rrd': No such file or directory
```

munin-node v2.0.9
