### PR TITLE
Adding new variable to allow monitoring of different pools

### DIFF
--- a/phpfpm_average
+++ b/phpfpm_average
@@ -16,6 +16,7 @@
 #%# capabilities=autoconf
 
 PHP_BIN=${phpbin-"php5-fpm"}
+PHP_POOL=${phppool-"www"}
 
 if [ "$1" = "autoconf" ]; then
 echo yes
@@ -35,5 +36,5 @@ exit 0
 fi
 
 echo -n "php_average.value "
-ps awwwux | grep $PHP_BIN | grep -v grep | grep -v master | awk '{total_mem = $6 * 1024 + total_mem; total_proc++} END{printf("%d\n", total_mem / total_proc)}'
+ps awwwux | grep "$PHP_BIN: pool $PHP_POOL" | grep -v grep | grep -v master | awk '{total_mem = $6 * 1024 + total_mem; total_proc++} END{printf("%d\n", total_mem / total_proc)}'
 

--- a/phpfpm_memory
+++ b/phpfpm_memory
@@ -5,6 +5,7 @@
 # Copyright TJ Stein 2010 http://constantshift.com
 
 my $PHP_BIN = exists $ENV{'phpbin'} ? $ENV{'phpbin'} : "php5-fpm";
+my $PHP_POOL = exists $ENV{'phppool'} ? $ENV{'phppool'} : "www";
 
 if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
         print "graph_title PHP5-FPM Memory Usage\n";
@@ -14,8 +15,7 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
                 print "graph_args --base 1024\n";
 } else {
         my $i = Integer;
-        @cmd = `ps auwx | grep $PHP_BIN | grep -v grep | grep -v phpfpm_memory`;
-
+        @cmd = `ps auwx | grep "$PHP_BIN: pool $PHP_POOL" | grep -v grep | grep -v phpfpm_memory`;
         foreach (@cmd) {
                 @return = split(/ +/, $_);
                 $i += @return[5]*1024;

--- a/phpfpm_processes
+++ b/phpfpm_processes
@@ -16,6 +16,7 @@
 #%# capabilities=autoconf
 
 PHP_BIN=${phpbin-"php5-fpm"}
+PHP_POOL=${phppool-"www"}
 
 if [ "$1" = "autoconf" ]; then
 echo yes
@@ -35,4 +36,4 @@ exit 0
 fi
 
 echo -n "php_processes.value "
-ps awwwux | grep $PHP_BIN | grep -v grep | wc -l
+ps awwwux | grep "$PHP_BIN: pool $PHP_POOL" | grep -v grep | wc -l


### PR DESCRIPTION
I run several PHP-FPM pools on my server to isolate different applications. In order to provide memory, processes and average process size data for each pool separately I've modified the plugins to include a new environment variable.

In order to use this, the munin-node file under plugin-conf.d has to include a new enviroment variable as follows:

```
[phpfpm_*]
env.phppool mypool
```
